### PR TITLE
chore: fix build error with elasticsearch 9.0.0

### DIFF
--- a/elasticsearch/src/main/java/com/infinilabs/stconvert/elasticsearch/STConvertAnalyzerProvider.java
+++ b/elasticsearch/src/main/java/com/infinilabs/stconvert/elasticsearch/STConvertAnalyzerProvider.java
@@ -28,7 +28,7 @@ public class STConvertAnalyzerProvider extends AbstractIndexAnalyzerProvider<STC
     private final STConvertAnalyzer analyzer;
 
     public STConvertAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(name, settings);
+        super(name);
         Boolean keepBoth = false;
         String type = settings.get("convert_type", "s2t");
         String delimiter = settings.get("delimiter", ",");

--- a/elasticsearch/src/main/java/com/infinilabs/stconvert/elasticsearch/STConvertTokenFilterFactory.java
+++ b/elasticsearch/src/main/java/com/infinilabs/stconvert/elasticsearch/STConvertTokenFilterFactory.java
@@ -31,7 +31,7 @@ public class STConvertTokenFilterFactory extends AbstractTokenFilterFactory {
     private Boolean keepBoth=false;
 
     public STConvertTokenFilterFactory(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(name, settings);
+        super(name);
         type = settings.get("convert_type", "s2t");
         delimiter = settings.get("delimiter", ",");
         String keepBothStr = settings.get("keep_both", "false");

--- a/elasticsearch/src/main/java/com/infinilabs/stconvert/elasticsearch/STConvertTokenizerFactory.java
+++ b/elasticsearch/src/main/java/com/infinilabs/stconvert/elasticsearch/STConvertTokenizerFactory.java
@@ -32,7 +32,7 @@ public class STConvertTokenizerFactory extends AbstractTokenizerFactory {
     private Boolean keepBoth=false;
 
     public STConvertTokenizerFactory(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, settings, name);
+        super(name);
          type = settings.get("convert_type", "s2t");
          delimiter = settings.get("delimiter", ",");
          String keepBothStr = settings.get("keep_both", "false");

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <lucene.version>9.3.0</lucene.version>
-        <elasticsearch.version>8.4.1</elasticsearch.version>
+        <elasticsearch.version>9.0.0</elasticsearch.version>
         <opensearch.version>2.0.1</opensearch.version>
         <maven.compiler.target>1.8</maven.compiler.target>
 


### PR DESCRIPTION
This pull request includes updates to the Elasticsearch plugin to align with version 9.0.0 and simplifies constructors for several factory classes. The most important changes include updating the Elasticsearch dependency version and modifying constructors to remove redundant parameters.

### Dependency Updates:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L37-R37): Updated the Elasticsearch dependency version from `8.4.1` to `9.0.0` to ensure compatibility with the latest version.

### Constructor Simplifications:

* [`STConvertAnalyzerProvider.java`](diffhunk://#diff-e9fa42f2e4bfbd84a6e2161403b7200d3d3a0e206150f65d7e6076fdf657ed87L31-R31): Simplified the constructor by removing the `settings` parameter from the call to the superclass constructor.
* [`STConvertTokenFilterFactory.java`](diffhunk://#diff-2f065b7460ee8830ec1903a8c126641db56c7d26a84f37659d761ca6ae99a4dfL34-R34): Simplified the constructor by removing the `settings` parameter from the call to the superclass constructor.
* [`STConvertTokenizerFactory.java`](diffhunk://#diff-86a2dec980dae31ac09e694d28f435b20cc002429296d5a56dd6409134b46862L35-R35): Simplified the constructor by replacing `indexSettings` and `settings` parameters with just `name` in the call to the superclass constructor.